### PR TITLE
Add authorization check with openai bearer header

### DIFF
--- a/nginx.conf
+++ b/nginx.conf
@@ -29,18 +29,36 @@ http {
       proxy_buffering off;
     }
 
-    location = /_validate_apikey {
-      internal;
+#    location = /_validate_apikey {
+#      internal;
+#
+#      if ($http_apikey = "") {
+#        return 401; # Unauthorized (no apikey)
+#      }
+#
+#      if ($api_client_name = "") {
+#        return 403; # Forbidden (unknown apikey)
+#      }
+#
+#      return 204; # OK (no content)
+#    }
+# }
 
-      if ($http_apikey = "") {
-        return 401; # Unauthorized (no apikey)
-      }
+  # this way, it will be compatible with openai Python object, where openai sends bearer token  in such format
+  location = /_validate_apikey {
+    internal;
 
-      if ($api_client_name = "") {
-        return 403; # Forbidden (unknown apikey)
-      }
-
-      return 204; # OK (no content)
+    # Extract the Bearer token from the Authorization header
+    set $http_apikey "";
+    if ($http_authorization ~* "Bearer (.+)") {
+        set $http_apikey $1;
     }
+    # Validate the extracted token against the mapped API keys
+    if ($api_client_name = "") {
+        return 401; # Unauthorized (invalid apikey)
+    }
+
+    return 204; # OK (no content)
   }
+  
 }


### PR DESCRIPTION
In order to use this with openai python object like this: 
```python
from openai import OpenAI

client = OpenAI(
    base_url = 'http://localhost:5050/v1',
    api_key='yassif+NiAyz2OCU97Jq2CRY5vzWqEk0jLrIkSd0zSMrviASL71R', # this is the api key, that will be compared with the api keys in the apiKeys.conf
)
```
I have added simple check for the header, the object creates "Bearer (.+)". With original code i was running into issues, because of the format of the header from the openai_python object.

With this small addition it works as expected.

Disclaimer:
This is my 'first' pull request to somebody else's repository, so if it is horrible in anyway, please let me know how so I can get better.